### PR TITLE
ci: use python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
 
 language: python
 python:
-  - "2.7"
+  - "3.7"
 
 # Cache PlatformIO packages using Travis CI container-based infrastructure
 sudo: false


### PR DESCRIPTION
see https://travis-ci.com/github/xreef/PCF8574_library/jobs/478886963#L238

```
$ platformio update

Error: Python 3.6 or later is required for this operation. 
```